### PR TITLE
Feat/add clock

### DIFF
--- a/components/elements/Header.tsx
+++ b/components/elements/Header.tsx
@@ -7,7 +7,6 @@ export default function Header() {
         <div className="navbar bg-neutral fixed top-0 z-50">
             <div className="navbar-start"></div>
             <div className="navbar-center">
-                {/* <a className="text-neutral-content text-xl font-bold">時計をここに置きたい</a> */}
                 <HeaderClock />
             </div>
             <div className="navbar-end"></div>

--- a/components/elements/Header.tsx
+++ b/components/elements/Header.tsx
@@ -1,11 +1,14 @@
+"use client";
 import React from "react";
+import HeaderClock from "./HeaderClock";
 
 export default function Header() {
     return (
         <div className="navbar bg-neutral fixed top-0 z-50">
             <div className="navbar-start"></div>
             <div className="navbar-center">
-                <a className="text-neutral-content text-xl font-bold">時計をここに置きたい</a>
+                {/* <a className="text-neutral-content text-xl font-bold">時計をここに置きたい</a> */}
+                <HeaderClock />
             </div>
             <div className="navbar-end"></div>
         </div>

--- a/components/elements/HeaderClock.tsx
+++ b/components/elements/HeaderClock.tsx
@@ -17,7 +17,6 @@ export default function HeaderClock() {
 
     return (
         <div>
-            {/* <h1>現在時刻:</h1> */}
             <p className="text-neutral-content text-4xl font-bold">{date} {time}</p>
         </div>
     );

--- a/components/elements/HeaderClock.tsx
+++ b/components/elements/HeaderClock.tsx
@@ -1,0 +1,24 @@
+"use client";
+import React, { useState, useEffect } from "react";
+import dayjs from "dayjs";
+
+export default function HeaderClock() {
+    const [time, setTime] = useState(dayjs().format("HH:mm:ss"));
+    const [date, setDate] = useState(dayjs().format("YYYY/MM/DD"));
+
+    useEffect(() => {
+        const interval = setInterval(() => {
+            setDate(dayjs().format("YYYY/MM/DD"));
+            setTime(dayjs().format("HH:mm:ss"));
+        }, 1000);
+
+        return () => clearInterval(interval);
+    }, []);
+
+    return (
+        <div>
+            {/* <h1>現在時刻:</h1> */}
+            <p className="text-neutral-content text-4xl font-bold">{date} {time}</p>
+        </div>
+    );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.47.8",
+        "dayjs": "^1.11.13",
         "next": "15.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -1982,6 +1983,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.13",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.47.8",
+    "dayjs": "^1.11.13",
     "next": "15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"


### PR DESCRIPTION
# 概要
- Clockの追加
----
# 内容
- ヘッダー部分に時計の追加
- 時計部分の実装のために、`dayjs`をインストール
----
# 観点
- ローカルで`npm run dev`を実行。
- localhost:3000での表示を確認。
- 以下のようになれば、正常
![image](https://github.com/user-attachments/assets/5907642e-92c6-4454-9ab9-235ca8619405)
----
# 方法
1. `git fetch origin feat/AddClock`
2. `git checkout FETCH_HEAD`
3. `npm install dayjs`
4. `npm run dev`